### PR TITLE
Update to track upstream changes

### DIFF
--- a/tokio-trace-env-logger/examples/hyper-echo/sloggish.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo/sloggish.rs
@@ -12,12 +12,15 @@
 //! [`slog` README]: https://github.com/slog-rs/slog#terminal-output-example
 extern crate ansi_term;
 extern crate humantime;
-extern crate tokio_trace_subscriber;
-
 use self::ansi_term::{Color, Style};
-use super::tokio_trace::{self, Id, Level, Subscriber};
+use super::tokio_trace::{
+    self,
+    field::{Field, Record},
+    Id, Level, Subscriber,
+};
 
 use std::{
+    cell::RefCell,
     collections::HashMap,
     fmt,
     io::{self, Write},
@@ -25,18 +28,52 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Mutex,
     },
+    thread,
     time::SystemTime,
 };
+
+/// Tracks the currently executing span on a per-thread basis.
+#[derive(Clone)]
+pub struct CurrentSpanPerThread {
+    current: &'static thread::LocalKey<RefCell<Vec<Id>>>,
+}
+
+impl CurrentSpanPerThread {
+    pub fn new() -> Self {
+        thread_local! {
+            static CURRENT: RefCell<Vec<Id>> = RefCell::new(vec![]);
+        };
+        Self { current: &CURRENT }
+    }
+
+    /// Returns the [`Id`](::Id) of the span in which the current thread is
+    /// executing, or `None` if it is not inside of a span.
+    pub fn id(&self) -> Option<Id> {
+        self.current
+            .with(|current| current.borrow().last().cloned())
+    }
+
+    pub fn enter(&self, span: Id) {
+        self.current.with(|current| {
+            current.borrow_mut().push(span);
+        })
+    }
+
+    pub fn exit(&self) {
+        self.current.with(|current| {
+            let _ = current.borrow_mut().pop();
+        })
+    }
+}
 
 pub struct SloggishSubscriber {
     // TODO: this can probably be unified with the "stack" that's used for
     // printing?
-    current: tokio_trace_subscriber::CurrentSpanPerThread,
+    current: CurrentSpanPerThread,
     indent_amount: usize,
     stderr: io::Stderr,
     stack: Mutex<Vec<Id>>,
     spans: Mutex<HashMap<Id, Span>>,
-    events: Mutex<HashMap<Id, Event>>,
     ids: AtomicUsize,
 }
 
@@ -45,72 +82,86 @@ struct Span {
     kvs: Vec<(&'static str, String)>,
 }
 
-struct Event {
-    level: tokio_trace::Level,
-    target: String,
-    message: String,
-    kvs: Vec<(&'static str, String)>,
+struct Event<'a> {
+    stderr: io::StderrLock<'a>,
+    comma: bool,
 }
 
-struct ColorLevel(Level);
+struct ColorLevel<'a>(&'a Level);
 
-impl fmt::Display for ColorLevel {
+impl<'a> fmt::Display for ColorLevel<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            Level::TRACE => Color::Purple.paint("TRACE"),
-            Level::DEBUG => Color::Blue.paint("DEBUG"),
-            Level::INFO => Color::Green.paint("INFO"),
-            Level::WARN => Color::Yellow.paint("WARN "),
-            Level::ERROR => Color::Red.paint("ERROR"),
+            &Level::TRACE => Color::Purple.paint("TRACE"),
+            &Level::DEBUG => Color::Blue.paint("DEBUG"),
+            &Level::INFO => Color::Green.paint("INFO "),
+            &Level::WARN => Color::Yellow.paint("WARN "),
+            &Level::ERROR => Color::Red.paint("ERROR"),
         }
         .fmt(f)
     }
 }
 
 impl Span {
-    fn new(parent: Option<Id>, _meta: &tokio_trace::Metadata) -> Self {
-        Self {
+    fn new(
+        parent: Option<Id>,
+        _meta: &tokio_trace::Metadata,
+        values: &tokio_trace::field::ValueSet,
+    ) -> Self {
+        let mut span = Self {
             parent,
             kvs: Vec::new(),
-        }
-    }
-
-    fn record(&mut self, key: &tokio_trace::field::Field, value: fmt::Arguments) {
-        let v = fmt::format(value);
-        self.kvs.push((key.name(), v));
+        };
+        values.record(&mut span);
+        span
     }
 }
 
-impl Event {
-    fn new(meta: &tokio_trace::Metadata) -> Self {
-        Self {
-            target: meta.target.to_owned(),
-            level: meta.level.clone(),
-            message: String::new(),
-            kvs: Vec::new(),
-        }
+impl Record for Span {
+    fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
+        self.kvs.push((field.name(), format!("{:?}", value)))
     }
+}
 
-    fn record(&mut self, key: &tokio_trace::field::Field, value: fmt::Arguments) {
-        if key.name() == "message" {
-            self.message = fmt::format(value);
-            return;
+impl<'a> Record for Event<'a> {
+    fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
+        write!(
+            &mut self.stderr,
+            "{comma} ",
+            comma = if self.comma { "," } else { "" },
+        )
+        .unwrap();
+        let name = field.name();
+        if name == "message" {
+            write!(
+                &mut self.stderr,
+                "{}",
+                // Have to alloc here due to `ansi_term`'s API...
+                Style::new().bold().paint(format!("{:?}", value))
+            )
+            .unwrap();
+            self.comma = true;
+        } else {
+            write!(
+                &mut self.stderr,
+                "{}: {:?}",
+                Style::new().bold().paint(name),
+                value
+            )
+            .unwrap();
+            self.comma = true;
         }
-
-        let v = fmt::format(value);
-        self.kvs.push((key.name(), v));
     }
 }
 
 impl SloggishSubscriber {
     pub fn new(indent_amount: usize) -> Self {
         Self {
-            current: tokio_trace_subscriber::CurrentSpanPerThread::new(),
+            current: CurrentSpanPerThread::new(),
             indent_amount,
             stderr: io::stderr(),
             stack: Mutex::new(vec![]),
             spans: Mutex::new(HashMap::new()),
-            events: Mutex::new(HashMap::new()),
             ids: AtomicUsize::new(0),
         }
     }
@@ -155,39 +206,26 @@ impl Subscriber for SloggishSubscriber {
         true
     }
 
-    fn new_span(&self, span: &tokio_trace::Metadata) -> tokio_trace::Id {
+    fn new_span(
+        &self,
+        span: &tokio_trace::Metadata,
+        values: &tokio_trace::field::ValueSet,
+    ) -> tokio_trace::Id {
         let next = self.ids.fetch_add(1, Ordering::SeqCst) as u64;
         let id = tokio_trace::Id::from_u64(next);
-        if span.name.contains("event") {
-            self.events
-                .lock()
-                .unwrap()
-                .insert(id.clone(), Event::new(span));
-        } else {
-            self.spans
-                .lock()
-                .unwrap()
-                .insert(id.clone(), Span::new(self.current.id(), span));
-        }
+        let span = Span::new(self.current.id(), span, values);
+        self.spans.lock().unwrap().insert(id.clone(), span);
         id
     }
 
-    fn record_debug(
-        &self,
-        span: &tokio_trace::Id,
-        name: &tokio_trace::field::Field,
-        value: &fmt::Debug,
-    ) {
-        if let Some(event) = self.events.lock().expect("mutex poisoned!").get_mut(span) {
-            return event.record(name, format_args!("{:?}", value));
-        };
+    fn record(&self, span: &tokio_trace::Id, values: &tokio_trace::field::ValueSet) {
         let mut spans = self.spans.lock().expect("mutex poisoned!");
         if let Some(span) = spans.get_mut(span) {
-            span.record(name, format_args!("{:?}", value))
+            values.record(span);
         }
     }
 
-    fn add_follows_from(&self, _span: &tokio_trace::Id, _follows: tokio_trace::Id) {
+    fn record_follows_from(&self, _span: &tokio_trace::Id, _follows: &tokio_trace::Id) {
         // unimplemented
     }
 
@@ -223,34 +261,33 @@ impl Subscriber for SloggishSubscriber {
         }
     }
 
+    fn event(&self, event: &tokio_trace::Event) {
+        let mut stderr = self.stderr.lock();
+        let indent = self.stack.lock().unwrap().len();
+        self.print_indent(&mut stderr, indent).unwrap();
+        write!(
+            &mut stderr,
+            "{timestamp} {level} {target}",
+            timestamp = humantime::format_rfc3339_seconds(SystemTime::now()),
+            level = ColorLevel(event.metadata().level()),
+            target = &event.metadata().target(),
+        )
+        .unwrap();
+        let mut recorder = Event {
+            stderr,
+            comma: false,
+        };
+        event.record(&mut recorder);
+        write!(&mut recorder.stderr, "\n").unwrap();
+    }
+
     #[inline]
     fn exit(&self, _span: &tokio_trace::Id) {
         // TODO: unify stack with current span
         self.current.exit();
     }
 
-    fn drop_span(&self, id: tokio_trace::Id) {
-        if let Some(event) = self.events.lock().expect("mutex poisoned").remove(&id) {
-            let mut stderr = self.stderr.lock();
-            let indent = self.stack.lock().unwrap().len();
-            self.print_indent(&mut stderr, indent).unwrap();
-            write!(
-                &mut stderr,
-                "{timestamp} {level} {target} {message}",
-                timestamp = humantime::format_rfc3339_seconds(SystemTime::now()),
-                level = ColorLevel(event.level),
-                target = &event.target,
-                message = Style::new().bold().paint(event.message),
-            )
-            .unwrap();
-            self.print_kvs(
-                &mut stderr,
-                event.kvs.iter().map(|&(ref k, ref v)| (k, v)),
-                ", ",
-            )
-            .unwrap();
-            write!(&mut stderr, "\n").unwrap();
-        }
+    fn drop_span(&self, _id: tokio_trace::Id) {
         // TODO: GC unneeded spans.
     }
 }

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -5,7 +5,7 @@ extern crate tokio;
 extern crate tokio_trace;
 
 use futures::{Async, Future, Poll, Sink, StartSend, Stream};
-use tokio_trace::{dispatcher, Dispatch, Span, Subscriber};
+use tokio_trace::{dispatcher, Dispatch, Span};
 
 pub mod executor;
 
@@ -21,11 +21,11 @@ pub trait Instrument: Sized {
 pub trait WithSubscriber: Sized {
     fn with_subscriber<S>(self, subscriber: S) -> WithDispatch<Self>
     where
-        S: Subscriber + Send + Sync + 'static,
+        S: Into<Dispatch>,
     {
         WithDispatch {
             inner: self,
-            dispatch: Dispatch::new(subscriber),
+            dispatch: subscriber.into(),
         }
     }
 }

--- a/tokio-trace-futures/src/test_support/event.rs
+++ b/tokio-trace-futures/src/test_support/event.rs
@@ -1,0 +1,92 @@
+#![allow(missing_docs)]
+use super::{field, metadata};
+
+use std::fmt;
+
+/// A mock event.
+///
+/// This is intended for use with the mock subscriber API in the
+/// `subscriber` module.
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct MockEvent {
+    pub fields: Option<field::Expect>,
+    metadata: metadata::Expect,
+}
+
+pub fn mock() -> MockEvent {
+    MockEvent {
+        ..Default::default()
+    }
+}
+
+impl MockEvent {
+    pub fn named<I>(self, name: I) -> Self
+    where
+        I: Into<String>,
+    {
+        Self {
+            metadata: metadata::Expect {
+                name: Some(name.into()),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
+
+    pub fn with_fields<I>(self, fields: I) -> Self
+    where
+        I: Into<field::Expect>,
+    {
+        Self {
+            fields: Some(fields.into()),
+            ..self
+        }
+    }
+
+    pub fn at_level(self, level: tokio_trace::Level) -> Self {
+        Self {
+            metadata: metadata::Expect {
+                level: Some(level),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
+
+    pub fn with_target<I>(self, target: I) -> Self
+    where
+        I: Into<String>,
+    {
+        Self {
+            metadata: metadata::Expect {
+                target: Some(target.into()),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
+
+    pub(in test_support) fn check(self, event: &tokio_trace::Event) {
+        let meta = event.metadata();
+        let name = meta.name();
+        self.metadata.check(meta, format_args!("event {}", name));
+        if let Some(mut expected_fields) = self.fields {
+            let mut checker = expected_fields.checker(format!("{}", name));
+            event.record(&mut checker);
+            checker.finish();
+        }
+    }
+}
+
+impl fmt::Display for MockEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "an event")?;
+        if let Some(ref name) = self.metadata.name {
+            write!(f, " named {:?}", name)?;
+        }
+        if let Some(ref fields) = self.fields {
+            write!(f, " with {}", fields)?
+        }
+        Ok(())
+    }
+}

--- a/tokio-trace-futures/src/test_support/field.rs
+++ b/tokio-trace-futures/src/test_support/field.rs
@@ -1,0 +1,224 @@
+use tokio_trace::{
+    callsite::Callsite,
+    field::{self, Field, Record, Value},
+};
+
+use std::{collections::HashMap, fmt};
+
+#[derive(Default, Debug, Eq, PartialEq)]
+pub struct Expect {
+    fields: HashMap<String, MockValue>,
+    only: bool,
+}
+
+#[derive(Debug)]
+pub struct MockField {
+    name: String,
+    value: MockValue,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum MockValue {
+    I64(i64),
+    U64(u64),
+    Bool(bool),
+    Str(String),
+    Debug(String),
+    Any,
+}
+
+pub fn mock<K>(name: K) -> MockField
+where
+    String: From<K>,
+{
+    MockField {
+        name: name.into(),
+        value: MockValue::Any,
+    }
+}
+
+impl MockField {
+    /// Expect a field with the given name and value.
+    pub fn with_value(self, value: &Value) -> Self {
+        Self {
+            value: MockValue::from(value),
+            ..self
+        }
+    }
+
+    pub fn and(self, other: MockField) -> Expect {
+        Expect {
+            fields: HashMap::new(),
+            only: false,
+        }
+        .and(self)
+        .and(other)
+    }
+
+    pub fn only(self) -> Expect {
+        Expect {
+            fields: HashMap::new(),
+            only: true,
+        }
+        .and(self)
+    }
+}
+
+impl Into<Expect> for MockField {
+    fn into(self) -> Expect {
+        Expect {
+            fields: HashMap::new(),
+            only: false,
+        }
+        .and(self)
+    }
+}
+
+impl Expect {
+    pub fn and(mut self, field: MockField) -> Self {
+        self.fields.insert(field.name, field.value);
+        self
+    }
+
+    /// Indicates that no fields other than those specified should be expected.
+    pub fn only(self) -> Self {
+        Self { only: true, ..self }
+    }
+
+    fn compare_or_panic(&mut self, name: &str, value: &Value, ctx: &str) {
+        let value = value.into();
+        match self.fields.remove(name) {
+            Some(MockValue::Any) => {}
+            Some(expected) => assert!(
+                expected == value,
+                "\nexpected `{}` to contain:\n\t`{}{}`\nbut got:\n\t`{}{}`",
+                ctx,
+                name,
+                expected,
+                name,
+                value
+            ),
+            None if self.only => panic!(
+                "\nexpected `{}` to contain only:\n\t`{}`\nbut got:\n\t`{}{}`",
+                ctx, self, name, value
+            ),
+            _ => {}
+        }
+    }
+
+    pub fn checker<'a>(&'a mut self, ctx: String) -> CheckRecorder<'a> {
+        CheckRecorder { expect: self, ctx }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+impl fmt::Display for MockValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MockValue::I64(v) => write!(f, ": i64 = {:?}", v),
+            MockValue::U64(v) => write!(f, ": u64 = {:?}", v),
+            MockValue::Bool(v) => write!(f, ": bool = {:?}", v),
+            MockValue::Str(v) => write!(f, ": &str = {:?}", v),
+            MockValue::Debug(v) => write!(f, ": &fmt::Debug = {:?}", v),
+            MockValue::Any => write!(f, ": _ = _"),
+        }
+    }
+}
+
+pub struct CheckRecorder<'a> {
+    expect: &'a mut Expect,
+    ctx: String,
+}
+
+impl<'a> Record for CheckRecorder<'a> {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.expect
+            .compare_or_panic(field.name(), &value, &self.ctx[..])
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.expect
+            .compare_or_panic(field.name(), &value, &self.ctx[..])
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.expect
+            .compare_or_panic(field.name(), &value, &self.ctx[..])
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.expect
+            .compare_or_panic(field.name(), &value, &self.ctx[..])
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
+        self.expect
+            .compare_or_panic(field.name(), &field::debug(value), &self.ctx)
+    }
+}
+
+impl<'a> CheckRecorder<'a> {
+    pub fn finish(self) {
+        assert!(
+            self.expect.fields.is_empty(),
+            "{}missing {}",
+            self.expect,
+            self.ctx
+        );
+    }
+}
+
+impl<'a> From<&'a Value> for MockValue {
+    fn from(value: &'a Value) -> Self {
+        struct MockValueBuilder {
+            value: Option<MockValue>,
+        }
+
+        impl Record for MockValueBuilder {
+            fn record_i64(&mut self, _: &Field, value: i64) {
+                self.value = Some(MockValue::I64(value));
+            }
+
+            fn record_u64(&mut self, _: &Field, value: u64) {
+                self.value = Some(MockValue::U64(value));
+            }
+
+            fn record_bool(&mut self, _: &Field, value: bool) {
+                self.value = Some(MockValue::Bool(value));
+            }
+
+            fn record_str(&mut self, _: &Field, value: &str) {
+                self.value = Some(MockValue::Str(value.to_owned()));
+            }
+
+            fn record_debug(&mut self, _: &Field, value: &fmt::Debug) {
+                self.value = Some(MockValue::Debug(format!("{:?}", value)));
+            }
+        }
+
+        let fake_field = callsite!(name: "fake", fields: fake_field)
+            .metadata()
+            .fields()
+            .field("fake_field")
+            .unwrap();
+        let mut builder = MockValueBuilder { value: None };
+        value.record(&fake_field, &mut builder);
+        builder
+            .value
+            .expect("finish called before a value was recorded")
+    }
+}
+
+impl fmt::Display for Expect {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "fields ")?;
+        let entries = self
+            .fields
+            .iter()
+            .map(|(k, v)| (field::display(k), field::display(v)));
+        f.debug_map().entries(entries).finish()
+    }
+}

--- a/tokio-trace-futures/src/test_support/metadata.rs
+++ b/tokio-trace-futures/src/test_support/metadata.rs
@@ -1,0 +1,64 @@
+use std::fmt;
+use tokio_trace::Metadata;
+
+#[derive(Debug, Eq, PartialEq, Default)]
+pub struct Expect {
+    pub name: Option<String>,
+    pub level: Option<tokio_trace::Level>,
+    pub target: Option<String>,
+}
+
+impl Expect {
+    pub(in test_support) fn check(&self, actual: &Metadata, ctx: fmt::Arguments) {
+        if let Some(ref expected_name) = self.name {
+            let name = actual.name();
+            assert!(
+                expected_name == name,
+                "expected {} to be named `{}`, but got one named `{}`",
+                ctx,
+                expected_name,
+                name
+            )
+        }
+
+        if let Some(ref expected_level) = self.level {
+            let level = actual.level();
+            assert!(
+                expected_level == level,
+                "expected {} to be at level `{:?}`, but it was at level `{:?}` instead",
+                ctx,
+                expected_level,
+                level,
+            )
+        }
+
+        if let Some(ref expected_target) = self.target {
+            let target = actual.target();
+            assert!(
+                expected_target == &target,
+                "expected {} to have target `{}`, but it had target `{}` instead",
+                ctx,
+                expected_target,
+                target,
+            )
+        }
+    }
+}
+
+impl fmt::Display for Expect {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref name) = self.name {
+            write!(f, "named `{}`", name)?;
+        }
+
+        if let Some(ref level) = self.level {
+            write!(f, " at the `{:?}` level", level)?;
+        }
+
+        if let Some(ref target) = self.target {
+            write!(f, " with target `{}`", target)?;
+        }
+
+        Ok(())
+    }
+}

--- a/tokio-trace-futures/src/test_support/mod.rs
+++ b/tokio-trace-futures/src/test_support/mod.rs
@@ -1,3 +1,6 @@
 #![allow(dead_code)]
+pub mod event;
+pub mod field;
+mod metadata;
 pub mod span;
 pub mod subscriber;

--- a/tokio-trace-futures/src/test_support/span.rs
+++ b/tokio-trace-futures/src/test_support/span.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+use super::{field, metadata};
 use std::fmt;
 
 /// A mock span.
@@ -7,8 +8,13 @@ use std::fmt;
 /// `subscriber` module.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct MockSpan {
-    pub name: Option<&'static str>,
-    // TODO: more
+    pub(in test_support) metadata: metadata::Expect,
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct NewSpan {
+    pub(in test_support) span: MockSpan,
+    pub(in test_support) fields: field::Expect,
 }
 
 pub fn mock() -> MockSpan {
@@ -18,19 +24,86 @@ pub fn mock() -> MockSpan {
 }
 
 impl MockSpan {
-    pub fn named(mut self, name: &'static str) -> Self {
-        self.name = Some(name);
-        self
+    pub fn named<I>(self, name: I) -> Self
+    where
+        I: Into<String>,
+    {
+        Self {
+            metadata: metadata::Expect {
+                name: Some(name.into()),
+                ..self.metadata
+            },
+            ..self
+        }
     }
 
-    // TODO: fields, etc
+    pub fn at_level(self, level: tokio_trace::Level) -> Self {
+        Self {
+            metadata: metadata::Expect {
+                level: Some(level),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
+
+    pub fn with_target<I>(self, target: I) -> Self
+    where
+        I: Into<String>,
+    {
+        Self {
+            metadata: metadata::Expect {
+                target: Some(target.into()),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.metadata.name.as_ref().map(String::as_ref)
+    }
+
+    pub fn with_field<I>(self, fields: I) -> NewSpan
+    where
+        I: Into<field::Expect>,
+    {
+        NewSpan {
+            span: self,
+            fields: fields.into(),
+        }
+    }
+
+    pub(in test_support) fn check_metadata(&self, actual: &tokio_trace::Metadata) {
+        self.metadata.check(actual, format_args!("span {}", self))
+    }
 }
 
 impl fmt::Display for MockSpan {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.name {
-            Some(name) => write!(f, "a span named {:?}", name),
-            None => write!(f, "any span"),
+        if self.metadata.name.is_some() {
+            write!(f, "a span{}", self.metadata)
+        } else {
+            write!(f, "any span{}", self.metadata)
         }
+    }
+}
+
+impl Into<NewSpan> for MockSpan {
+    fn into(self) -> NewSpan {
+        NewSpan {
+            span: self,
+            ..Default::default()
+        }
+    }
+}
+
+impl fmt::Display for NewSpan {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "a new span{}", self.span.metadata)?;
+        if !self.fields.is_empty() {
+            write!(f, " with {}", self.fields)?;
+        }
+        Ok(())
     }
 }

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use tokio_trace::{field, subscriber::Subscriber, Id, Metadata};
+use tokio_trace::{field, subscriber::Subscriber, Id, Metadata, Event};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -95,16 +94,20 @@ where
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_span(&self, meta: &Metadata) -> Id {
+    fn new_span(&self, meta: &Metadata, _values: &field::ValueSet) -> Id {
         self.registry.new_id(meta)
     }
 
-    fn record_debug(&self, _span: &Id, _name: &field::Field, _value: &fmt::Debug) {
+    fn record(&self, _span: &Id, _values: &field::ValueSet) {
         unimplemented!()
     }
 
-    fn add_follows_from(&self, span: &Id, follows: Id) {
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
         self.registry.add_follows_from(span, follows)
+    }
+
+    fn event(&self, _event: &Event) {
+        unimplemented!()
     }
 
     fn enter(&self, id: &Id) {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -58,7 +58,7 @@ pub trait RegisterSpan {
     /// registry knows about, or if a cyclical relationship would be created
     /// (i.e., some span _a_ which proceeds some other span _b_ may not also
     /// follow from _b_), it should do nothing.
-    fn add_follows_from(&self, span: &Id, follows: Id);
+    fn add_follows_from(&self, span: &Id, follows: &Id);
 
     /// Queries the registry for an iterator over the IDs of the spans that
     /// `span` follows from.
@@ -181,7 +181,7 @@ impl RegisterSpan for IncreasingCounter {
         id
     }
 
-    fn add_follows_from(&self, _span: &Id, _follows: Id) {
+    fn add_follows_from(&self, _span: &Id, _follows: &Id) {
         // unimplemented
     }
 


### PR DESCRIPTION
tokio-rs/tokio@9dc0129fe2c108bf1d0d52fd38e60455213bace7 merged a fairly large change to the upstream `tokio-trace` in order to support more efficient batching of field values. This changed several of the `tokio-trace` and `tokio-trace-core` APIs that the crates in this repository depend on. This PR updates all the `tokio-trace-nursery` crates to compile against the latest upstream `tokio-trace`. Note that the `tokio-trace-subscriber` crate will still require a fairly significant rewrite to actually be functional, but that API has needed to be reworked for a while.