### PR TITLE
proc-macros: Make basic example more useful

### DIFF
--- a/tokio-trace-proc-macros/examples/basic.rs
+++ b/tokio-trace-proc-macros/examples/basic.rs
@@ -9,7 +9,10 @@ use tokio_trace::field;
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
-    let subscriber = tokio_trace_log::TraceLogger::new();
+    let subscriber = tokio_trace_log::TraceLogger::builder()
+        .with_span_entry(true)
+        .with_span_exits(true)
+        .finish();
 
     tokio_trace::subscriber::with_default(subscriber, || {
         let num: u64 = 1;
@@ -28,5 +31,6 @@ fn main() {
 #[trace]
 #[inline]
 fn suggest_band() -> String {
+    debug!("Suggesting a band.");
     format!("Wild Pink")
 }


### PR DESCRIPTION
There was no event in `fn suggest_band`, so the span was entered but
nothing showed it doing so. A `debug!` line was added as well as
configuring the logger to log span entry and exits. This way, we see the
traced function has its own span.

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>