### PR TITLE
proc-macros: Pass params to the function as fields

### DIFF
--- a/tokio-trace-proc-macros/examples/args.rs
+++ b/tokio-trace-proc-macros/examples/args.rs
@@ -14,7 +14,7 @@ fn nth_fibonacci(n: u64) -> u64 {
         1
     } else {
         debug!("Recursing");
-        nth_fibonacci(n-1) + nth_fibonacci(n-2)
+        nth_fibonacci(n - 1) + nth_fibonacci(n - 2)
     }
 }
 
@@ -32,15 +32,13 @@ fn fibonacci_seq(to: u64) -> Vec<u64> {
 
 fn main() {
     env_logger::Builder::new().parse("trace").init();
-    let subscriber = tokio_trace_log::TraceLogger::builder().with_parent_fields(false).finish();
+    let subscriber = tokio_trace_log::TraceLogger::builder()
+        .with_parent_fields(false)
+        .finish();
 
     tokio_trace::subscriber::with_default(subscriber, || {
         let n: u64 = 5;
         let sequence = fibonacci_seq(n);
-        info!(
-            "The first {} fibonacci numbers are {:?}",
-            n,
-            sequence
-        );
+        info!("The first {} fibonacci numbers are {:?}", n, sequence);
     })
 }

--- a/tokio-trace-proc-macros/examples/args.rs
+++ b/tokio-trace-proc-macros/examples/args.rs
@@ -1,0 +1,46 @@
+#[macro_use]
+extern crate tokio_trace;
+#[macro_use]
+extern crate tokio_trace_proc_macros;
+extern crate env_logger;
+extern crate tokio_trace_log;
+
+use tokio_trace::field;
+
+#[trace]
+fn nth_fibonacci(n: u64) -> u64 {
+    if n == 0 || n == 1 {
+        debug!("Base case");
+        1
+    } else {
+        debug!("Recursing");
+        nth_fibonacci(n-1) + nth_fibonacci(n-2)
+    }
+}
+
+#[trace]
+fn fibonacci_seq(to: u64) -> Vec<u64> {
+    let mut sequence = vec![];
+
+    for n in 0..=to {
+        debug!("Pushing {n} fibonacci", n = n);
+        sequence.push(nth_fibonacci(n));
+    }
+
+    sequence
+}
+
+fn main() {
+    env_logger::Builder::new().parse("trace").init();
+    let subscriber = tokio_trace_log::TraceLogger::builder().with_parent_fields(false).finish();
+
+    tokio_trace::subscriber::with_default(subscriber, || {
+        let n: u64 = 5;
+        let sequence = fibonacci_seq(n);
+        info!(
+            "The first {} fibonacci numbers are {:?}",
+            n,
+            sequence
+        );
+    })
+}

--- a/tokio-trace-proc-macros/src/lib.rs
+++ b/tokio-trace-proc-macros/src/lib.rs
@@ -53,8 +53,8 @@ pub fn trace(_args: TokenStream, item: TokenStream) -> TokenStream {
         #vis #constness #unsafety #asyncness #abi fn #ident(#params) #return_type {
             span!(
                 #ident_str,
-                traced_function = &#ident_str,
-                #(#param_names = tokio_trace::field::debug(&#param_names_clone)),*
+                traced_function = &#ident_str
+                #(, #param_names = tokio_trace::field::debug(&#param_names_clone)),*
             )
             .enter(move || {
                 #block


### PR DESCRIPTION
The parameters to the function are now passed as fields into `span!` so
that we can see what arguments a traced function is called with.

Before:
```
DEBUG 2019-02-08T22:51:06Z: args: fibonacci_seq: Pushing 0 fibonacci; traced_function="fibonacci_seq";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: fibonacci_seq: Pushing 1 fibonacci; traced_function="fibonacci_seq";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: fibonacci_seq: Pushing 2 fibonacci; traced_function="fibonacci_seq";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Recursing; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: fibonacci_seq: Pushing 3 fibonacci; traced_function="fibonacci_seq";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Recursing; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Recursing; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci";
DEBUG 2019-02-08T22:51:06Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci";
```

After:
```
DEBUG 2019-02-08T22:53:03Z: args: fibonacci_seq: Pushing 0 fibonacci; traced_function="fibonacci_seq"; to=5;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci"; n=0;
DEBUG 2019-02-08T22:53:03Z: args: fibonacci_seq: Pushing 1 fibonacci; traced_function="fibonacci_seq"; to=5;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci"; n=1;
DEBUG 2019-02-08T22:53:03Z: args: fibonacci_seq: Pushing 2 fibonacci; traced_function="fibonacci_seq"; to=5;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Recursing; traced_function="nth_fibonacci"; n=2;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci"; n=1;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci"; n=0;
DEBUG 2019-02-08T22:53:03Z: args: fibonacci_seq: Pushing 3 fibonacci; traced_function="fibonacci_seq"; to=5;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Recursing; traced_function="nth_fibonacci"; n=3;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Recursing; traced_function="nth_fibonacci"; n=2;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci"; n=1;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci"; n=0;
DEBUG 2019-02-08T22:53:03Z: args: nth_fibonacci: Base case; traced_function="nth_fibonacci"; n=1;
```

Closes #5 

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
Co-authored-by: Eliza Weisman <eliza@buoyantio>