### PR TITLE
fmt: Reduce span store lock contention

### DIFF
--- a/tokio-trace-fmt/Cargo.toml
+++ b/tokio-trace-fmt/Cargo.toml
@@ -12,5 +12,8 @@ tokio-trace-core = { git = "https://github.com/tokio-rs/tokio" }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = "0.4.0"
 
+parking_lot = { version = "0.7"}
+lock_api = "0.1"
+
 [dev-dependencies]
 tokio-trace = "0.0.1"

--- a/tokio-trace-fmt/Cargo.toml
+++ b/tokio-trace-fmt/Cargo.toml
@@ -10,6 +10,7 @@ ansi = ["ansi_term"]
 [dependencies]
 tokio-trace-core = { git = "https://github.com/tokio-rs/tokio" }
 ansi_term = { version = "0.11", optional = true }
+owning_ref = "0.4.0"
 
 [dev-dependencies]
 tokio-trace = "0.0.1"

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -223,7 +223,7 @@ impl Store {
         // index from the stack.
         loop {
             // Acquire a snapshot of the head of the free list.
-            let head = self.next.load(Ordering::Acquire);
+            let head = self.next.load(Ordering::Relaxed);
 
             {
                 // Try to insert the span without modifying the overall


### PR DESCRIPTION
This branch rewrites the span store in `tokio-trace-fmt` to
significantly reduce lock contention. Rather than requiring a single
global write lock be acquired for any modification to the span store,
write locks may now be acquired on individual spans without a global
write lock. The write lock around the slab itself must only be acquired
in order to grow the slab.

The significantly reduced lock contention ameliorates any additional
performance hit incurred by the fix in #17. H2 instrumented with
`tokio-trace` can manage over 35RPS in `h2load`, at maximum verbosity.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>