### PR TITLE
chore: Update to pick up tokio-rs/tokio#923

### DIFF
--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -6,11 +6,7 @@ extern crate lock_api;
 extern crate owning_ref;
 extern crate parking_lot;
 
-use tokio_trace_core::{
-    field,
-    subscriber::Interest,
-    Event, Metadata,
-};
+use tokio_trace_core::{field, subscriber::Interest, Event, Metadata};
 
 use std::{cell::RefCell, fmt, io};
 

--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -6,7 +6,11 @@ extern crate lock_api;
 extern crate owning_ref;
 extern crate parking_lot;
 
-use tokio_trace_core::{field, subscriber::Interest, Event, Metadata};
+use tokio_trace_core::{
+    field,
+    subscriber::Interest,
+    Event, Metadata,
+};
 
 use std::{cell::RefCell, fmt, io};
 
@@ -84,9 +88,10 @@ where
     }
 
     #[inline]
-    fn new_span(&self, metadata: &Metadata, values: &field::ValueSet) -> span::Id {
-        let span = span::Data::new(metadata);
-        self.spans.new_span(span, values, &self.new_recorder)
+    fn new_span(&self, attrs: &span::Attributes) -> span::Id {
+        let span = span::Data::new(attrs.metadata());
+        self.spans
+            .new_span(span, attrs.values(), &self.new_recorder)
     }
 
     #[inline]

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -7,7 +7,7 @@ use std::{
 use owning_ref::OwningHandle;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-pub use tokio_trace_core::Span as Id;
+pub(crate) use tokio_trace_core::span::{Attributes, Id};
 use tokio_trace_core::{dispatcher, field, Metadata};
 
 pub struct Span<'a> {

--- a/tokio-trace-futures/src/test_support/subscriber.rs
+++ b/tokio-trace-futures/src/test_support/subscriber.rs
@@ -12,7 +12,11 @@ use std::{
         Arc, Mutex,
     },
 };
-use tokio_trace::{field, Event, Id, Metadata, Subscriber};
+use tokio_trace::{
+    field,
+    span::{self, Id},
+    Event, Metadata, Subscriber,
+};
 
 #[derive(Debug, Eq, PartialEq)]
 enum Expect {
@@ -172,7 +176,7 @@ impl<F: Fn(&Metadata) -> bool> Subscriber for Running<F> {
         // TODO: it should be possible to expect spans to follow from other spans
     }
 
-    fn new_span(&self, attrs: &tokio_trace::span::Attributes) -> Id {
+    fn new_span(&self, attrs: &span::Attributes) -> Id {
         let meta = attrs.metadata();
         let values = attrs.values();
         let id = self.ids.fetch_add(1, Ordering::SeqCst);

--- a/tokio-trace-futures/src/test_support/subscriber.rs
+++ b/tokio-trace-futures/src/test_support/subscriber.rs
@@ -172,7 +172,9 @@ impl<F: Fn(&Metadata) -> bool> Subscriber for Running<F> {
         // TODO: it should be possible to expect spans to follow from other spans
     }
 
-    fn new_span(&self, meta: &Metadata, values: &field::ValueSet) -> Id {
+    fn new_span(&self, attrs: &tokio_trace::span::Attributes) -> Id {
+        let meta = attrs.metadata();
+        let values = attrs.values();
         let id = self.ids.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         println!(

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -35,7 +35,7 @@ use std::{
 
 use tokio_trace::{
     callsite::{self, Callsite},
-    field,
+    field, span,
     subscriber::{self, Subscriber},
     Event, Id, Metadata,
 };
@@ -328,7 +328,7 @@ impl Subscriber for TraceLogger {
         log::logger().enabled(&metadata.as_log())
     }
 
-    fn new_span(&self, meta: &Metadata, values: &field::ValueSet) -> Id {
+    fn new_span(&self, attrs: &span::Attributes) -> Id {
         let id = self.next_id();
         let mut spans = self.spans.lock().unwrap();
         let mut fields = String::new();
@@ -340,8 +340,8 @@ impl Subscriber for TraceLogger {
                 next_parent = parent.parent.as_ref();
             }
         }
-        let mut span = SpanLineBuilder::new(parent, meta, fields);
-        values.record(&mut span);
+        let mut span = SpanLineBuilder::new(parent, attrs.metadata(), fields);
+        attrs.values().record(&mut span);
         spans.insert(id.clone(), span);
         id
     }

--- a/tokio-trace-proc-macros/examples/args.rs
+++ b/tokio-trace-proc-macros/examples/args.rs
@@ -5,7 +5,6 @@ extern crate tokio_trace_proc_macros;
 extern crate env_logger;
 extern crate tokio_trace_fmt;
 
-use tokio_trace::field;
 
 #[trace]
 fn nth_fibonacci(n: u64) -> u64 {

--- a/tokio-trace-proc-macros/examples/args.rs
+++ b/tokio-trace-proc-macros/examples/args.rs
@@ -5,7 +5,6 @@ extern crate tokio_trace_proc_macros;
 extern crate env_logger;
 extern crate tokio_trace_fmt;
 
-
 #[trace]
 fn nth_fibonacci(n: u64) -> u64 {
     if n == 0 || n == 1 {

--- a/tokio-trace-subscriber/src/compose.rs
+++ b/tokio-trace-subscriber/src/compose.rs
@@ -1,4 +1,9 @@
-use tokio_trace::{field, subscriber::Subscriber, Event, Id, Metadata};
+use tokio_trace::{
+    field,
+    span::{self, Id},
+    subscriber::Subscriber,
+    Event, Metadata,
+};
 use {filter::NoFilter, observe::NoObserver, Filter, Observe, RegisterSpan};
 
 #[derive(Debug, Clone)]
@@ -94,8 +99,8 @@ where
         self.filter.enabled(metadata) && self.observer.filter().enabled(metadata)
     }
 
-    fn new_span(&self, meta: &Metadata, _values: &field::ValueSet) -> Id {
-        self.registry.new_id(meta)
+    fn new_span(&self, attrs: &span::Attributes) -> Id {
+        self.registry.new_id(attrs)
     }
 
     fn record(&self, _span: &Id, _values: &field::ValueSet) {

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -1,4 +1,7 @@
-use tokio_trace::{span::Id, Metadata};
+use tokio_trace::{
+    span::{Attributes, Id},
+    Metadata,
+};
 
 use std::{
     cmp,
@@ -34,11 +37,11 @@ pub trait RegisterSpan {
     /// from all calls to this function, if they so choose.
     ///
     /// [span ID]: ../span/struct.Id.html
-    fn new_span(&self, new_span: &'static Metadata<'static>) -> Id {
+    fn new_span(&self, new_span: &Attributes) -> Id {
         self.new_id(new_span)
     }
 
-    fn new_id(&self, new_id: &Metadata) -> Id;
+    fn new_id(&self, new_id: &Attributes) -> Id;
 
     /// Adds an indication that `span` follows from the span with the id
     /// `follows`.
@@ -166,16 +169,16 @@ impl Default for IncreasingCounter {
 impl RegisterSpan for IncreasingCounter {
     type PriorSpans = iter::Empty<Id>;
 
-    fn new_span(&self, new_span: &'static Metadata<'static>) -> Id {
+    fn new_span(&self, new_span: &Attributes) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         if let Ok(mut spans) = self.spans.lock() {
-            spans.insert(id.clone(), new_span);
+            // spans.insert(id.clone(), new_span);
         }
         id
     }
 
-    fn new_id(&self, _new: &Metadata) -> Id {
+    fn new_id(&self, _new: &Attributes) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
         id


### PR DESCRIPTION
This branch updates the nursery crates to build with tokio-rs/tokio#923,
which changes the `Subscriber::new_span` function's signature.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>