### PR TITLE
fmt: Fix filtering of spans when they are included in the directive

### DIFF
--- a/tokio-trace-fmt/src/filter.rs
+++ b/tokio-trace-fmt/src/filter.rs
@@ -96,10 +96,6 @@ where
 
 impl Filter for EnvFilter {
     fn callsite_enabled(&self, metadata: &Metadata, _: &span::Context) -> Interest {
-        if metadata.level() > &self.max_level {
-            return Interest::never();
-        }
-
         let mut interest = Interest::never();
         for directive in self.directives_for(metadata) {
             let accepts_level = metadata.level() <= &directive.level;


### PR DESCRIPTION
This if statement was blocking spans from being registered if the span's level was below that of the one specified as the max_level. This means if a user expressed specific interest in that span and the max level was above it the sub will not enable that. This now enables that type of feature.