### PR TITLE
chore: Temporarily fix upstream version incompatibility

### DIFF
--- a/tokio-trace-tower-http/Cargo.toml
+++ b/tokio-trace-tower-http/Cargo.toml
@@ -14,7 +14,7 @@ http = "0.1"
 [dev-dependencies]
 bytes = "0.4"
 h2 = "0.1.11"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2.git" }
+tower-h2 = { git = "https://github.com/tower-rs/tower-h2.git", rev = "b9feae345a72396d82dc23d52a5a62689178bc40" }
 string = { git = "https://github.com/carllerche/string" }
 tokio = "0.1"
 tokio-current-thread = "0.1.1"
@@ -24,5 +24,4 @@ tokio-trace-fmt = { path = "../tokio-trace-fmt" }
 tokio-io = "0.1"
 ansi_term = "0.11"
 humantime = "1.1.1"
-
 env_logger = "0.5"


### PR DESCRIPTION
This branch temporarily changes `tokio-trace-tower-http`'s
dev-dependency on `tower-h2` to require a fixed git SHA. 

This is because the upstream change
tower-rs/tower-h2@226523df4fc33eeafd653f45676ffc01ee7b75c6 introduced a
dependency on the crates.io version of `tower-service`, while other
dependencies of `tower-h2` require a Git version of `tower-service`. 

While `tower-h2` resolves this using a `[patch]`, we don't seem to be
able to, as it appears that `[patch]` does not effect dev-dependencies
(possibly a cargo bug?). Therefore, I've just set the `tower-h2` dev
dependency to depend on the git SHA from before the upstream change
landed, which should fix the CI build for now.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>