### PR TITLE
fmt: Add basic span value filtering

### DIFF
--- a/tokio-trace-fmt/src/filter.rs
+++ b/tokio-trace-fmt/src/filter.rs
@@ -154,7 +154,7 @@ impl Filter for EnvFilter {
                                     let fields = span.fields();
                                     let matcher = format!("{}={:?}", field, val);
 
-                                    if fields == matcher {
+                                    if fields.contains(matcher) {
                                         Err(())
                                     } else {
                                         Ok(())


### PR DESCRIPTION
This adds a new syntax for filtering based on values inside a span. The syntax can be used like so:

```bash
app[spanA{field:val}]=level
```

currently, it only works with strings due to how values are recorded into the slot.