### PR TITLE
chore: Update for upstream changes

### DIFF
--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -120,7 +120,7 @@ fn main() {
     let subscriber = tokio_trace_fmt::FmtSubscriber::builder().full().finish();
     tokio_trace_env_logger::try_init().expect("init log adapter");
 
-    tokio_trace::dispatcher::with_default(tokio_trace::Dispatch::new(subscriber), || {
+    tokio_trace::subscriber::with_default(subscriber, || {
         let addr: ::std::net::SocketAddr = ([127, 0, 0, 1], 3000).into();
         let mut server_span = span!("server", local = &field::debug(addr));
         let server = tokio::net::TcpListener::bind(&addr)

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -201,7 +201,6 @@ fn id_to_idx(id: &Id) -> usize {
     id.into_u64() as usize - 1
 }
 
-
 impl Store {
     pub fn with_capacity(capacity: usize) -> Self {
         Store {
@@ -288,9 +287,7 @@ impl Store {
     #[inline]
     pub fn get(&self, id: &Id) -> Option<Span> {
         let lock = OwningHandle::try_new(self.inner.read(), |slab| {
-            unsafe { &*slab }
-                .read_slot(id_to_idx(id))
-                .ok_or(())
+            unsafe { &*slab }.read_slot(id_to_idx(id)).ok_or(())
         })
         .ok()?;
         Some(Span { lock })

--- a/tokio-trace-futures/src/test_support/subscriber.rs
+++ b/tokio-trace-futures/src/test_support/subscriber.rs
@@ -126,7 +126,7 @@ where
         let subscriber = Running {
             spans: Mutex::new(HashMap::new()),
             expected,
-            ids: AtomicUsize::new(0),
+            ids: AtomicUsize::new(1),
             filter: self.filter,
         };
         (subscriber, handle)

--- a/tokio-trace-subscriber/src/registry.rs
+++ b/tokio-trace-subscriber/src/registry.rs
@@ -160,7 +160,7 @@ pub fn increasing_counter() -> IncreasingCounter {
 impl Default for IncreasingCounter {
     fn default() -> Self {
         Self {
-            next_id: AtomicUsize::new(0),
+            next_id: AtomicUsize::new(1),
             spans: Mutex::new(HashMap::new()),
         }
     }
@@ -172,9 +172,9 @@ impl RegisterSpan for IncreasingCounter {
     fn new_span(&self, _new_span: &Attributes) -> Id {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let id = Id::from_u64(id as u64);
-        if let Ok(spans) = self.spans.lock() {
-            // spans.insert(id.clone(), new_span);
-        }
+        // if let Ok(spans) = self.spans.lock() {
+        //     // spans.insert(id.clone(), new_span);
+        // }
         id
     }
 


### PR DESCRIPTION
This branch updates the nursery to ensure compatibility with
tokio-rs/tokio#971 and tokio-rs/tokio#973.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>