### PR TITLE
fmt: Make `FmtSubscriber` more friendly to being in a stacked

### DIFF
--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -135,18 +135,13 @@ where
         });
     }
 
-    fn enter(&self, span: &span::Id) {
+    fn enter(&self, id: &span::Id) {
         // TODO: add on_enter hook
-        let span = self.clone_span(span);
-        span::push(span);
+        span::push(id);
     }
 
-    fn exit(&self, span: &span::Id) {
-        // TODO: add on_exit hook
-        if let Some(popped) = span::pop() {
-            debug_assert!(&popped == span);
-            self.drop_span(popped);
-        }
+    fn exit(&self, id: &span::Id) {
+        span::pop(id)
     }
 
     fn clone_span(&self, id: &span::Id) -> span::Id {

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -74,17 +74,28 @@ pub(crate) fn current() -> Option<Id> {
         .ok()?
 }
 
-pub(crate) fn push(id: Id) {
+pub(crate) fn push(id: &Id) {
+    let id = dispatcher::get_default(|subscriber| {
+        subscriber.clone_span(id)
+    });
     let _ = CONTEXT.try_with(|current| {
         current.borrow_mut().push(id);
     });
 }
 
-pub(crate) fn pop() -> Option<Id> {
-    CONTEXT
+pub(crate) fn pop(expected_id: &Id) {
+    let mut id = CONTEXT
         .try_with(|current| current.borrow_mut().pop())
-        .ok()?
+        .ok()
+        .and_then(|i| i);
+    if id.is_some() {
+        debug_assert_eq!(Some(expected_id), id.as_ref());
+        dispatcher::get_default(|subscriber| {
+            subscriber.drop_span(id.take().unwrap());
+        })
+    }
 }
+
 
 // ===== impl Span =====
 
@@ -339,12 +350,7 @@ impl Store {
         // from std::Arc);
         atomic::fence(Ordering::Acquire);
 
-        let data = this.remove(&self.next, idx);
-        // Continue propagating the drop up the span's parent tree, to avoid
-        // round-trips through the dispatcher.
-        if let Some(parent) = data.and_then(|data| data.parent) {
-            self.drop_span(parent)
-        }
+        this.remove(&self.next, idx);
     }
 }
 
@@ -355,6 +361,22 @@ impl Data {
             parent: current(),
             ref_count: AtomicUsize::new(1),
             is_empty: true,
+        }
+    }
+}
+
+impl Drop for Data {
+    fn drop(&mut self) {
+        // We have to actually unpack the option inside the `get_default`
+        // closure, since it is a `FnMut`, but testing that there _is_ a value
+        // here lets us avoid the thread-local access if we don't need the
+        // dispatcher at all.
+        if self.parent.is_some() {
+            dispatcher::get_default(|subscriber| {
+                if let Some(parent) = self.parent.take() {
+                    subscriber.drop_span(parent);
+                }
+            })
         }
     }
 }

--- a/tokio-trace-fmt/src/span.rs
+++ b/tokio-trace-fmt/src/span.rs
@@ -75,9 +75,7 @@ pub(crate) fn current() -> Option<Id> {
 }
 
 pub(crate) fn push(id: &Id) {
-    let id = dispatcher::get_default(|subscriber| {
-        subscriber.clone_span(id)
-    });
+    let id = dispatcher::get_default(|subscriber| subscriber.clone_span(id));
     let _ = CONTEXT.try_with(|current| {
         current.borrow_mut().push(id);
     });
@@ -95,7 +93,6 @@ pub(crate) fn pop(expected_id: &Id) {
         })
     }
 }
-
 
 // ===== impl Span =====
 


### PR DESCRIPTION
Currently, the `FmtSubscriber` doesn't play nice in situations where it
might be wrapped by an outer type which also implements `Subscriber`, if
that outer subscriber requires span refcounting. This is because there
are several cases where `FmtSubscriber` will call `clone_span` or
`drop_span` on `self` directly rather than on the current dispatcher,
meaning that if another subscriber is layered around the
`FmtSubscriber`, it won't see those calls to `clone_span` or
`drop_span`.

I've fixed this by ensuring that `FmtSubscriber` never calls the
ref-counting functions on `self`, and always calls them on the current
subscriber instead.

In the future, the best way to deal with this issue is probably to not
compose subscribers with this kind of layering; but to have one central
registry that does all the span ID lifecycle management instead. Since
the `tokio-trace-subscriber` crate doesn't have a working implementation
of this yet, however, stacking subscribers is a valid stop-gap solution
for some use-cases.

Since the original behaviour (calling functions on `self` directly) was
intended as a performance optimization (to avoid taking a round-trip
through the dispatcher and to avoid reacquiring read locks on the span
store repeatedly), this does have a bit of a performance impact. Here
are `h2load` results from the `h2` crate's `server` example instrumented
with `tokio-trace-fmt`:

Before:
```
finished in 13.88s, 720.60 req/s, 21.12KB/s
requests: 10000 total, 10000 started, 10000 done, 10000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 10000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 293.06KB (300090) total, 9.77KB (10000) headers (space savings 90.00%), 107.42KB (110000) data
                     min         max         mean         sd        +/- sd
time for request:     2.96ms    223.36ms      6.56ms      7.75ms    98.90%
time for connect:      245us       395us       318us        62us    60.00%
time to 1st byte:    11.02ms     11.50ms     11.32ms       198us    80.00%
req/s           :     144.12      158.37      152.53        7.40    60.00%
```

After:

```
finished in 14.42s, 693.33 req/s, 20.32KB/s
requests: 10000 total, 10000 started, 10000 done, 10000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 10000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 293.06KB (300090) total, 9.77KB (10000) headers (space savings 90.00%), 107.42KB (110000) data
                     min         max         mean         sd        +/- sd
time for request:     2.88ms    198.11ms      6.38ms     12.38ms    99.04%
time for connect:     1.78ms      1.91ms      1.83ms        51us    60.00%
time to 1st byte:    12.93ms     13.68ms     13.26ms       281us    60.00%
req/s           :     138.67      179.36      157.65       14.78    60.00%
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>