### PR TITLE
tower-http: Fix tower-util breaking the build

### DIFF
--- a/tokio-trace-tower-http/Cargo.toml
+++ b/tokio-trace-tower-http/Cargo.toml
@@ -8,7 +8,7 @@ tokio-trace = "0.0.1"
 tokio-trace-futures = { path = "../tokio-trace-futures" }
 futures = "0.1"
 tower-service = "0.2"
-tower-util = { git = "https://github.com/tower-rs/tower.git" }
+tower = { git = "https://github.com/tower-rs/tower.git" }
 http = "0.1"
 
 [dev-dependencies]

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate http;
-extern crate tower_service;
 extern crate tower;
+extern crate tower_service;
 #[macro_use]
 extern crate tokio_trace;
 extern crate futures;
@@ -11,8 +11,8 @@ use std::marker::PhantomData;
 use futures::{Future, Poll};
 use tokio_trace::{field, Span};
 use tokio_trace_futures::{Instrument, Instrumented};
-use tower_service::Service;
 use tower::MakeService;
+use tower_service::Service;
 
 #[derive(Debug)]
 pub struct InstrumentedHttpService<'span, T> {

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate http;
 extern crate tower_service;
-extern crate tower_util;
+extern crate tower;
 #[macro_use]
 extern crate tokio_trace;
 extern crate futures;
@@ -12,7 +12,7 @@ use futures::{Future, Poll};
 use tokio_trace::{field, Span};
 use tokio_trace_futures::{Instrument, Instrumented};
 use tower_service::Service;
-use tower_util::MakeService;
+use tower::MakeService;
 
 #[derive(Debug)]
 pub struct InstrumentedHttpService<'span, T> {


### PR DESCRIPTION
tower-rs/tower#197 renamed the `tower-util` crate to just `tower`. This
commit updates our dependencies to track that (and thus fix the build).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>