### PR TITLE
chore: Update for tokio-rs/tokio#988

### DIFF
--- a/tokio-trace-env-logger/examples/hyper-echo.rs
+++ b/tokio-trace-env-logger/examples/hyper-echo.rs
@@ -20,7 +20,7 @@ use tokio_trace_futures::{Instrument, Instrumented};
 
 type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
-fn echo(req: Request<Body>) -> Instrumented<'static, BoxFut> {
+fn echo(req: Request<Body>) -> Instrumented<BoxFut> {
     span!(
         "request",
         method = &field::debug(req.method()),

--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -20,9 +20,9 @@ macro_rules! deinstrument_err {
     };
 }
 
-impl<'a, T, F> Executor<F> for Instrumented<'a, T>
+impl<T, F> Executor<F> for Instrumented<T>
 where
-    T: Executor<Instrumented<'a, F>>,
+    T: Executor<Instrumented<F>>,
     F: Future<Item = (), Error = ()>,
 {
     fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
@@ -32,7 +32,7 @@ where
 }
 
 #[cfg(feature = "with-tokio")]
-impl<T> TokioExecutor for Instrumented<'static, T>
+impl<T> TokioExecutor for Instrumented<T>
 where
     T: TokioExecutor,
 {
@@ -47,7 +47,7 @@ where
 }
 
 #[cfg(feature = "with-tokio")]
-impl Instrumented<'static, Runtime> {
+impl Instrumented<Runtime> {
     /// Spawn an instrumented future onto the Tokio runtime.
     ///
     /// This spawns the given future onto the runtime's executor, usually a
@@ -97,13 +97,13 @@ impl Instrumented<'static, Runtime> {
     /// The instrumented handle functions identically to a
     /// `tokio::runtime::TaskExecutor`, but instruments the spawned
     /// futures prior to spawning them.
-    pub fn executor(&self) -> Instrumented<'static, TaskExecutor> {
+    pub fn executor(&self) -> Instrumented<TaskExecutor> {
         self.inner.executor().instrument(self.span.clone())
     }
 }
 
 #[cfg(feature = "with-tokio")]
-impl Instrumented<'static, current_thread::Runtime> {
+impl Instrumented<current_thread::Runtime> {
     /// Spawn an instrumented future onto the single-threaded Tokio runtime.
     ///
     /// This method simply wraps a call to `current_thread::Runtime::spawn`,
@@ -160,7 +160,7 @@ impl Instrumented<'static, current_thread::Runtime> {
     /// The instrumented handle functions identically to a
     /// `tokio::runtime::current_thread::Handle`, but instruments the spawned
     /// futures prior to spawning them.
-    pub fn handle(&self) -> Instrumented<'static, current_thread::Handle> {
+    pub fn handle(&self) -> Instrumented<current_thread::Handle> {
         self.inner.handle().instrument(self.span.clone())
     }
 }

--- a/tokio-trace-tower-http/src/lib.rs
+++ b/tokio-trace-tower-http/src/lib.rs
@@ -15,26 +15,26 @@ use tower::MakeService;
 use tower_service::Service;
 
 #[derive(Debug)]
-pub struct InstrumentedHttpService<'span, T> {
+pub struct InstrumentedHttpService<T> {
     inner: T,
-    span: Span<'span>,
+    span: Span,
 }
 
-impl<'span, T> InstrumentedHttpService<'span, T> {
-    pub fn new(inner: T, span: Span<'span>) -> Self {
+impl<T> InstrumentedHttpService<T> {
+    pub fn new(inner: T, span: Span) -> Self {
         Self { inner, span }
     }
 }
 
 #[derive(Debug)]
-pub struct InstrumentedMakeService<'span, T, B> {
+pub struct InstrumentedMakeService<T, B> {
     inner: T,
-    span: Span<'span>,
+    span: Span,
     _p: PhantomData<fn() -> B>,
 }
 
-impl<'span, T, B> InstrumentedMakeService<'span, T, B> {
-    pub fn new<Target>(inner: T, span: Span<'span>) -> Self
+impl<T, B> InstrumentedMakeService<T, B> {
+    pub fn new<Target>(inner: T, span: Span) -> Self
     where
         T: MakeService<Target, http::Request<B>>,
     {
@@ -46,13 +46,13 @@ impl<'span, T, B> InstrumentedMakeService<'span, T, B> {
     }
 }
 
-impl<'span, T, Target, B> Service<Target> for InstrumentedMakeService<'span, T, B>
+impl<T, Target, B> Service<Target> for InstrumentedMakeService<T, B>
 where
     T: MakeService<Target, http::Request<B>>,
 {
-    type Response = InstrumentedHttpService<'span, T::Service>;
+    type Response = InstrumentedHttpService<T::Service>;
     type Error = T::MakeError;
-    type Future = InstrumentedMakeServiceFuture<'span, T::Future>;
+    type Future = InstrumentedMakeServiceFuture<T::Future>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner.poll_ready()
@@ -65,16 +65,16 @@ where
     }
 }
 
-pub struct InstrumentedMakeServiceFuture<'span, T> {
+pub struct InstrumentedMakeServiceFuture<T> {
     inner: T,
-    span: Span<'span>,
+    span: Span,
 }
 
-impl<'span, T> Future for InstrumentedMakeServiceFuture<'span, T>
+impl<T> Future for InstrumentedMakeServiceFuture<T>
 where
     T: Future,
 {
-    type Item = InstrumentedHttpService<'span, T::Item>;
+    type Item = InstrumentedHttpService<T::Item>;
     type Error = T::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let span2 = self.span.clone();
@@ -88,12 +88,12 @@ where
     }
 }
 
-impl<'span, T, B> Service<http::Request<B>> for InstrumentedHttpService<'span, T>
+impl<T, B> Service<http::Request<B>> for InstrumentedHttpService<T>
 where
     T: Service<http::Request<B>>,
 {
     type Response = T::Response;
-    type Future = Instrumented<'span, T::Future>;
+    type Future = Instrumented<T::Future>;
     type Error = T::Error;
 
     fn poll_ready(&mut self) -> futures::Poll<(), Self::Error> {


### PR DESCRIPTION
tokio-rs/tokio#988 removed the generic lifetime parameter from
`Span`. This branch updates the nursery crates to match.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>