### PR TITLE
Tokio trace instrumentation example

### DIFF
--- a/tokio-trace-futures/examples/proxy_server.rs
+++ b/tokio-trace-futures/examples/proxy_server.rs
@@ -3,8 +3,6 @@ This example has been taken and modified from here :
 https://raw.githubusercontent.com/tokio-rs/tokio/master/tokio/examples/proxy.rs
 */
 
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio;
 #[macro_use]

--- a/tokio-trace-futures/examples/proxy_server.rs
+++ b/tokio-trace-futures/examples/proxy_server.rs
@@ -15,7 +15,7 @@ use tokio_trace_futures::Instrument;
 
 use std::env;
 use std::io::{self, Read, Write};
-use std::net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr};
+use std::net::{Shutdown, SocketAddr};
 use std::sync::{Arc, Mutex};
 
 use tokio::io::{copy, shutdown};
@@ -39,14 +39,14 @@ fn main() -> Result<(), Box<std::error::Error>> {
         .map_err(|e| debug!(msg = "error accepting socket", error = field::display(e)))
         .for_each(move |client| {
             let server = TcpStream::connect(&server_addr);
-            let mut client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+            let mut client_addr : Option<SocketAddr> = None;
             match client.peer_addr() {
                 Ok(x) => {
-                    client_addr = x;
+                    client_addr = Some(x);
                     info!(message = "client connected", client_addr = field::debug(x))
                 }
                 Err(e) => debug!(
-                    message = "could not get client info",
+                    message = "Could not get client information",
                     error = field::display(e)
                 ),
             }
@@ -99,7 +99,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
                 })
                 .instrument(span!(
                     "transfer completed",
-                    client_address = field::debug(&client_addr),
+                    client_address = field::debug(&client_addr.unwrap()),
                     server_address = field::debug(&server_addr)
                 ));
 

--- a/tokio-trace-futures/examples/proxy_server.rs
+++ b/tokio-trace-futures/examples/proxy_server.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
         .map_err(|e| debug!(msg = "error accepting socket", error = field::display(e)))
         .for_each(move |client| {
             let server = TcpStream::connect(&server_addr);
-            let mut client_addr: Option<SocketAddr> = None;
+            let mut client_addr = None;
             match client.peer_addr() {
                 Ok(x) => {
                     client_addr = Some(x);
@@ -99,7 +99,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
                 })
                 .instrument(span!(
                     "transfer completed",
-                    client_address = field::debug(&client_addr.unwrap()),
+                    client_address = field::debug(&client_addr),
                     server_address = field::debug(&server_addr)
                 ));
 

--- a/tokio-trace-futures/examples/proxy_server.rs
+++ b/tokio-trace-futures/examples/proxy_server.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
         .map_err(|e| debug!(msg = "error accepting socket", error = field::display(e)))
         .for_each(move |client| {
             let server = TcpStream::connect(&server_addr);
-            let mut client_addr : Option<SocketAddr> = None;
+            let mut client_addr: Option<SocketAddr> = None;
             match client.peer_addr() {
                 Ok(x) => {
                     client_addr = Some(x);

--- a/tokio-trace-futures/examples/proxy_server.rs
+++ b/tokio-trace-futures/examples/proxy_server.rs
@@ -1,0 +1,113 @@
+/*
+This example has been taken and modified from here : 
+https://raw.githubusercontent.com/tokio-rs/tokio/master/tokio/examples/proxy.rs
+*/
+
+#![deny(warnings)]
+
+extern crate tokio;
+
+use std::env;
+use std::io::{self, Read, Write};
+use std::net::{Shutdown, SocketAddr};
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{copy, shutdown};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::prelude::*;
+
+fn main() -> Result<(), Box<std::error::Error>> {
+    let listen_addr = env::args().nth(1).unwrap_or("127.0.0.1:8081".to_string());
+    let listen_addr = listen_addr.parse::<SocketAddr>()?;
+
+    let server_addr = env::args().nth(2).unwrap_or("127.0.0.1:8080".to_string());
+    let server_addr = server_addr.parse::<SocketAddr>()?;
+
+    // Create a TCP listener which will listen for incoming connections.
+    let socket = TcpListener::bind(&listen_addr)?;
+    println!("Listening on: {}", listen_addr);
+    println!("Proxying to: {}", server_addr);
+
+    let done = socket
+        .incoming()
+        .map_err(|e| println!("error accepting socket; error = {:?}", e))
+        .for_each(move |client| {
+            let server = TcpStream::connect(&server_addr);
+            let amounts = server.and_then(move |server| {
+                // Create separate read/write handles for the TCP clients that we're
+                // proxying data between. Note that typically you'd use
+                // `AsyncRead::split` for this operation, but we want our writer
+                // handles to have a custom implementation of `shutdown` which
+                // actually calls `TcpStream::shutdown` to ensure that EOF is
+                // transmitted properly across the proxied connection.
+                //
+                // As a result, we wrap up our client/server manually in arcs and
+                // use the impls below on our custom `MyTcpStream` type.
+                let client_reader = MyTcpStream(Arc::new(Mutex::new(client)));
+                let client_writer = client_reader.clone();
+                let server_reader = MyTcpStream(Arc::new(Mutex::new(server)));
+                let server_writer = server_reader.clone();
+
+                // Copy the data (in parallel) between the client and the server.
+                // After the copy is done we indicate to the remote side that we've
+                // finished by shutting down the connection.
+                let client_to_server = copy(client_reader, server_writer)
+                    .and_then(|(n, _, server_writer)| shutdown(server_writer).map(move |_| n));
+
+                let server_to_client = copy(server_reader, client_writer)
+                    .and_then(|(n, _, client_writer)| shutdown(client_writer).map(move |_| n));
+
+                client_to_server.join(server_to_client)
+            });
+
+            let msg = amounts
+                .map(move |(from_client, from_server)| {
+                    println!(
+                        "client wrote {} bytes and received {} bytes",
+                        from_client, from_server
+                    );
+                })
+                .map_err(|e| {
+                    // Don't panic. Maybe the client just disconnected too soon.
+                    println!("error: {}", e);
+                });
+
+            tokio::spawn(msg);
+
+            Ok(())
+        });
+
+    tokio::run(done);
+    Ok(())
+}
+
+// This is a custom type used to have a custom implementation of the
+// `AsyncWrite::shutdown` method which actually calls `TcpStream::shutdown` to
+// notify the remote end that we're done writing.
+#[derive(Clone)]
+struct MyTcpStream(Arc<Mutex<TcpStream>>);
+
+impl Read for MyTcpStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().read(buf)
+    }
+}
+
+impl Write for MyTcpStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl AsyncRead for MyTcpStream {}
+
+impl AsyncWrite for MyTcpStream {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        try!(self.0.lock().unwrap().shutdown(Shutdown::Write));
+        Ok(().into())
+    }
+}

--- a/tokio-trace-futures/examples/proxy_server.rs
+++ b/tokio-trace-futures/examples/proxy_server.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
                         message = "client connected",
                         client_addr = field::display(&client_addr)
                     )
-                },
+                }
                 Err(e) => debug!(
                     message = "could not get client info",
                     error = field::display(e)
@@ -101,7 +101,8 @@ fn main() -> Result<(), Box<std::error::Error>> {
                     // Don't panic. Maybe the client just disconnected too soon.
                     debug!(error = field::display(e));
                 })
-                .instrument(span!("transfer",
+                .instrument(span!(
+                    "transfer",
                     client_address = field::debug(&client_addr),
                     server_address = field::debug(&server_addr.to_string())
                 ));


### PR DESCRIPTION
This is an example of demonstrating `tokio-trace` instrumentation. I have used the proxy server implementation in the Tokio crate examples.