### PR TITLE
fmt: Ignore r# if it is included as the field name

### DIFF
--- a/tokio-trace-fmt/src/default.rs
+++ b/tokio-trace-fmt/src/default.rs
@@ -91,16 +91,11 @@ impl<'a> field::Visit for Recorder<'a> {
 
     fn record_debug(&mut self, field: &Field, value: &fmt::Debug) {
         self.maybe_pad();
-        if field.name() == "message" {
-            let _ = write!(self.writer, "{:?}", value);
-        } else {
-            if field.name().starts_with("r#") {
-                let field = field.name();
-                let _ = write!(self.writer, "{}={:?}", &field[2..], value);
-            } else {
-                let _ = write!(self.writer, "{}={:?}", field, value);
-            }
-        }
+        let _ = match field.name() {
+            "message" => write!(self.writer, "{:?}", value),
+            name if name.starts_with("r#") => write!(self.writer, "{}={:?}", &name[2..], value),
+            name => write!(self.writer, "{}={:?}", name, value),
+        };
     }
 }
 

--- a/tokio-trace-fmt/src/default.rs
+++ b/tokio-trace-fmt/src/default.rs
@@ -94,7 +94,12 @@ impl<'a> field::Visit for Recorder<'a> {
         if field.name() == "message" {
             let _ = write!(self.writer, "{:?}", value);
         } else {
-            let _ = write!(self.writer, "{}={:?}", field, value);
+            if field.name().starts_with("r#") {
+                let field = field.name();
+                let _ = write!(self.writer, "{}={:?}", &field[2..], value);
+            } else {
+                let _ = write!(self.writer, "{}={:?}", field, value);
+            }
         }
     }
 }


### PR DESCRIPTION
This allows users to use field names that are reserved keywords like so `info!(r#type = typetag)` and it will ignore the `r#` only if it is the first two characters.