### PR TITLE
fmt: Allow downcasting a FmtSubscriber to its components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ members = [
     "tokio-trace-macros",
     "tokio-trace-subscriber"
 ]
-
-[patch.crates-io]
-tokio-trace-core = { git = "https://github.com/tokio-rs/tokio"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ members = [
     "tokio-trace-subscriber"
 ]
 
+[patch.crates-io]
+tokio-trace-core = { git = "https://github.com/tokio-rs/tokio"}


### PR DESCRIPTION
This commit overrides the `downcast_raw` method on `FmtSubscriber` so
that a `FmtSubscriber` can also be downcast to pointers to its generic
components (its on-event callback, filter, and `NewVisitor`).

This will allow implementations of the components of a `FmtSubscriber`
to support "out-of-band" APIs that don't require knowledge of the types
of the _other_ components to downcast the subscriber to a concrete type.
This is intended for use-cases such as dynamic filter reloading (#42).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>