### PR TITLE
fix: update nursery to build with trace 0.1 and core 0.2

### DIFF
--- a/tokio-trace-env-logger/Cargo.toml
+++ b/tokio-trace-env-logger/Cargo.toml
@@ -9,7 +9,7 @@ env_logger = "0.5"
 log = "0.4"
 
 [dev-dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 tokio-trace-fmt = { path = "../tokio-trace-fmt" }
 tokio-trace-futures = { path = "../tokio-trace-futures" }
 tokio-trace-subscriber = { path = "../tokio-trace-subscriber" }

--- a/tokio-trace-fmt/Cargo.toml
+++ b/tokio-trace-fmt/Cargo.toml
@@ -8,7 +8,7 @@ default = ["ansi"]
 ansi = ["ansi_term"]
 
 [dependencies]
-tokio-trace-core = "0.1"
+tokio-trace-core = "0.2.0"
 ansi_term = { version = "0.11", optional = true }
 regex = "1"
 lazy_static = "1"
@@ -17,4 +17,4 @@ parking_lot = { version = "0.7"}
 lock_api = "0.1"
 
 [dev-dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"

--- a/tokio-trace-fmt/src/filter/env.rs
+++ b/tokio-trace-fmt/src/filter/env.rs
@@ -316,8 +316,7 @@ mod tests {
     struct Cs;
 
     impl Callsite for Cs {
-        fn add_interest(&self, _interest: Interest) {}
-        fn clear_interest(&self) {}
+        fn set_interest(&self, _interest: Interest) {}
         fn metadata(&self) -> &Metadata {
             unimplemented!()
         }
@@ -328,7 +327,17 @@ mod tests {
         let filter = EnvFilter::from("app=debug");
         let store = Store::with_capacity(1);
         let ctx = Context::new(&store, &NewRecorder);
-        let meta = Metadata::new("mySpan", "app", Level::TRACE, None, None, None, &[], &Cs);
+        let meta = Metadata::new(
+            "mySpan",
+            "app",
+            Level::TRACE,
+            None,
+            None,
+            None,
+            &[],
+            &Cs,
+            Kind::SPAN,
+        );
 
         let interest = filter.callsite_enabled(&meta, &ctx);
         assert!(interest.is_never());
@@ -339,7 +348,17 @@ mod tests {
         let filter = EnvFilter::from("app[mySpan]=debug");
         let store = Store::with_capacity(1);
         let ctx = Context::new(&store, &NewRecorder);
-        let meta = Metadata::new("mySpan", "app", Level::TRACE, None, None, None, &[], &Cs);
+        let meta = Metadata::new(
+            "mySpan",
+            "app",
+            Level::TRACE,
+            None,
+            None,
+            None,
+            &[],
+            &Cs,
+            Kind::SPAN,
+        );
 
         let interest = filter.callsite_enabled(&meta, &ctx);
         assert!(interest.is_always());
@@ -359,6 +378,7 @@ mod tests {
             None,
             &["field=\"value\""],
             &Cs,
+            Kind::SPAN,
         );
 
         let interest = filter.callsite_enabled(&meta, &ctx);
@@ -379,6 +399,7 @@ mod tests {
             None,
             &["field=\"value\""],
             &Cs,
+            Kind::SPAN,
         );
 
         let interest = filter.callsite_enabled(&meta, &ctx);
@@ -399,6 +420,7 @@ mod tests {
             None,
             &["field=\"value\""],
             &Cs,
+            Kind::SPAN,
         );
 
         let interest = filter.callsite_enabled(&meta, &ctx);
@@ -419,6 +441,7 @@ mod tests {
             None,
             &["field=\"value\""],
             &Cs,
+            Kind::SPAN,
         );
 
         let interest = filter.callsite_enabled(&meta, &ctx);

--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -9,7 +9,7 @@ with-tokio = ["tokio"]
 
 [dependencies]
 futures = "0.1"
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 tokio = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/tokio-trace-futures/src/test_support/field.rs
+++ b/tokio-trace-futures/src/test_support/field.rs
@@ -1,6 +1,10 @@
-use tokio_trace::{callsite::Callsite, field::{self, Field, Value, Visit}, metadata::Kind};
+use tokio_trace::{
+    callsite::Callsite,
+    field::{self, Field, Value, Visit},
+    metadata::Kind,
+};
 
-use std::{fmt, collections::HashMap};
+use std::{collections::HashMap, fmt};
 
 #[derive(Default, Debug, Eq, PartialEq)]
 pub struct Expect {
@@ -47,15 +51,17 @@ impl MockField {
         Expect {
             fields: HashMap::new(),
             only: false,
-        }.and(self)
-            .and(other)
+        }
+        .and(self)
+        .and(other)
     }
 
     pub fn only(self) -> Expect {
         Expect {
             fields: HashMap::new(),
             only: true,
-        }.and(self)
+        }
+        .and(self)
     }
 }
 
@@ -64,7 +70,8 @@ impl Into<Expect> for MockField {
         Expect {
             fields: HashMap::new(),
             only: false,
-        }.and(self)
+        }
+        .and(self)
     }
 }
 
@@ -209,7 +216,8 @@ impl<'a> From<&'a Value> for MockValue {
 impl fmt::Display for Expect {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "fields ")?;
-        let entries = self.fields
+        let entries = self
+            .fields
             .iter()
             .map(|(k, v)| (field::display(k), field::display(v)));
         f.debug_map().entries(entries).finish()

--- a/tokio-trace-futures/src/test_support/field.rs
+++ b/tokio-trace-futures/src/test_support/field.rs
@@ -199,11 +199,12 @@ impl<'a> From<&'a Value> for MockValue {
             }
         }
 
-        let fake_field = callsite!(name: "fake", fields: fake_field)
-            .metadata()
-            .fields()
-            .field("fake_field")
-            .unwrap();
+        let fake_field =
+            callsite!(name: "fake", kind: tokio_trace::metadata::Kind::EVENT, fields: fake_field)
+                .metadata()
+                .fields()
+                .field("fake_field")
+                .unwrap();
         let mut builder = MockValueBuilder { value: None };
         value.record(&fake_field, &mut builder);
         builder

--- a/tokio-trace-futures/src/test_support/field.rs
+++ b/tokio-trace-futures/src/test_support/field.rs
@@ -1,9 +1,6 @@
-use tokio_trace::{
-    callsite::Callsite,
-    field::{self, Field, Value, Visit},
-};
+use tokio_trace::{callsite::Callsite, field::{self, Field, Value, Visit}, metadata::Kind};
 
-use std::{collections::HashMap, fmt};
+use std::{fmt, collections::HashMap};
 
 #[derive(Default, Debug, Eq, PartialEq)]
 pub struct Expect {
@@ -50,17 +47,15 @@ impl MockField {
         Expect {
             fields: HashMap::new(),
             only: false,
-        }
-        .and(self)
-        .and(other)
+        }.and(self)
+            .and(other)
     }
 
     pub fn only(self) -> Expect {
         Expect {
             fields: HashMap::new(),
             only: true,
-        }
-        .and(self)
+        }.and(self)
     }
 }
 
@@ -69,8 +64,7 @@ impl Into<Expect> for MockField {
         Expect {
             fields: HashMap::new(),
             only: false,
-        }
-        .and(self)
+        }.and(self)
     }
 }
 
@@ -199,12 +193,11 @@ impl<'a> From<&'a Value> for MockValue {
             }
         }
 
-        let fake_field =
-            callsite!(name: "fake", kind: tokio_trace::metadata::Kind::EVENT, fields: fake_field)
-                .metadata()
-                .fields()
-                .field("fake_field")
-                .unwrap();
+        let fake_field = callsite!(name: "fake", kind: Kind::EVENT, fields: fake_field)
+            .metadata()
+            .fields()
+            .field("fake_field")
+            .unwrap();
         let mut builder = MockValueBuilder { value: None };
         value.record(&fake_field, &mut builder);
         builder
@@ -216,8 +209,7 @@ impl<'a> From<&'a Value> for MockValue {
 impl fmt::Display for Expect {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "fields ")?;
-        let entries = self
-            .fields
+        let entries = self.fields
             .iter()
             .map(|(k, v)| (field::display(k), field::display(v)));
         f.debug_map().entries(entries).finish()

--- a/tokio-trace-log/Cargo.toml
+++ b/tokio-trace-log/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 tokio-trace-subscriber = { path = "../tokio-trace-subscriber" }
 log = "0.4"

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -35,7 +35,9 @@ use std::{
 
 use tokio_trace::{
     callsite::{self, Callsite},
-    field, span,
+    field,
+    metadata::Kind,
+    span,
     subscriber::{self, Subscriber},
     Event, Id, Metadata,
 };
@@ -79,8 +81,7 @@ impl<'a> AsTrace for log::Record<'a> {
     fn as_trace(&self) -> Self::Trace {
         struct LogCallsite;
         impl Callsite for LogCallsite {
-            fn add_interest(&self, _interest: subscriber::Interest) {}
-            fn clear_interest(&self) {}
+            fn set_interest(&self, _interest: subscriber::Interest) {}
             fn metadata(&self) -> &Metadata {
                 // Since we never register the log callsite, this method is
                 // never actually called. So it's okay to return mostly empty metadata.
@@ -95,6 +96,7 @@ impl<'a> AsTrace for log::Record<'a> {
                         names: &["message"],
                         callsite: callsite::Identifier(&LogCallsite),
                     },
+                    kind: Kind::SPAN,
                 };
                 &EMPTY_META
             }
@@ -108,6 +110,7 @@ impl<'a> AsTrace for log::Record<'a> {
             self.line(),
             &["message"],
             &LogCallsite,
+            Kind::SPAN,
         )
     }
 }

--- a/tokio-trace-macros/Cargo.toml
+++ b/tokio-trace-macros/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 
 [dev-dependencies]
 tokio-trace-log = { path = "../tokio-trace-log" }

--- a/tokio-trace-macros/src/lib.rs
+++ b/tokio-trace-macros/src/lib.rs
@@ -33,6 +33,7 @@ macro_rules! dbg {
         };
         let callsite = callsite! {
             name: concat!("event:trace_dbg(", stringify!($ex), ")"),
+            kind: tokio_trace::metadata::Kind::EVENT,
             target: $target,
             level: $level,
             fields: $ex

--- a/tokio-trace-proc-macros/Cargo.toml
+++ b/tokio-trace-proc-macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Eliza Weisman <eliza@buoyant.io>", "David Barsky <dbarsky@amazon.com
 proc-macro = true
 
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 syn = { version = "0.15", features = ["full", "extra-traits"] }
 quote = "0.6"
 proc-macro2 = { version = "0.4", features = ["nightly"] }

--- a/tokio-trace-slog/Cargo.toml
+++ b/tokio-trace-slog/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
 
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"

--- a/tokio-trace-subscriber/Cargo.toml
+++ b/tokio-trace-subscriber/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 
 [dev-dependencies]
 tokio-trace-log = { path = "../tokio-trace-log" }

--- a/tokio-trace-tower-http/Cargo.toml
+++ b/tokio-trace-tower-http/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 tokio-trace-futures = { path = "../tokio-trace-futures" }
 futures = "0.1"
 tower-service = "0.2"

--- a/tokio-trace-tower/Cargo.toml
+++ b/tokio-trace-tower/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1.0"
 tokio-trace-futures = { path = "../tokio-trace-futures" }
 futures = "0.1"
 tower-service = "0.2"


### PR DESCRIPTION
Recent changes to tokio-trace and tokio-trace-core broke the build on
master for tokio-trace-nursery. This change adds missing fields to calls
in tokio-trace-nursery so that it compiles again.