### PR TITLE
fix: allow updates to span fields

### DIFF
--- a/tokio-trace-proc-macros/Cargo.toml
+++ b/tokio-trace-proc-macros/Cargo.toml
@@ -8,9 +8,10 @@ proc-macro = true
 
 [dependencies]
 tokio-trace = "0.1.0"
-syn = { version = "0.15", features = ["full", "extra-traits"] }
+syn = { version = "0.15", features = ["derive"] }
 quote = "0.6"
 proc-macro2 = { version = "0.4", features = ["nightly"] }
+syn-mid = "0.3.0"
 
 [dev-dependencies]
 tokio-trace-fmt = { path = "../tokio-trace-fmt" }

--- a/tokio-trace-proc-macros/src/lib.rs
+++ b/tokio-trace-proc-macros/src/lib.rs
@@ -4,41 +4,24 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 extern crate proc_macro2;
+extern crate syn_mid;
 extern crate tokio_trace;
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use syn::token::{Async, Const, Unsafe};
-use syn::{Abi, ArgCaptured, Attribute, Block, FnArg, Ident, ItemFn, Pat, PatIdent, Visibility};
+use syn_mid::{ArgCaptured, FnArg, ItemFn, Pat, PatIdent};
 
 #[proc_macro_attribute]
-pub fn trace(_args: TokenStream, item: TokenStream) -> TokenStream {
-    let input: ItemFn = parse_macro_input!(item as ItemFn);
+pub fn trace(_args: TokenStream, function: TokenStream) -> TokenStream {
+    let mut function: ItemFn = parse_macro_input!(function);
+
+    let body = function.block.stmts;
     let call_site = Span::call_site();
+    let ident_str = function.ident.to_string();
 
-    // these are needed ahead of time, as ItemFn contains the function body _and_
-    // isn't representable inside a quote!/quote_spanned! macro
-    // (Syn's ToTokens isn't implemented for ItemFn)
-    let attrs: Vec<Attribute> = input.clone().attrs;
-    let vis: Visibility = input.clone().vis;
-    let constness: Option<Const> = input.clone().constness;
-    let unsafety: Option<Unsafe> = input.clone().unsafety;
-    let asyncness: Option<Async> = input.clone().asyncness;
-    let abi: Option<Abi> = input.clone().abi;
-
-    // function body
-    let block: Box<Block> = input.clone().block;
-    // function name
-    let ident: Ident = input.clone().ident;
-    let ident_str = ident.to_string();
-
-    let return_type = input.clone().decl.output;
-    let params = input.clone().decl.inputs;
-    let param_names: Vec<Ident> = input
-        .clone()
-        .decl
+    let param_names: Vec<_> = function
         .inputs
-        .into_iter()
+        .iter()
         .filter_map(|param| match param {
             FnArg::Captured(ArgCaptured {
                 pat: Pat::Ident(PatIdent { ident, .. }),
@@ -49,19 +32,20 @@ pub fn trace(_args: TokenStream, item: TokenStream) -> TokenStream {
         .collect();
     let param_names_clone = param_names.clone();
 
-    quote_spanned!(call_site=>
-        #(#attrs) *
-        #vis #constness #unsafety #asyncness #abi fn #ident(#params) #return_type {
-            span!(
-                tokio_trace::Level::TRACE,
-                #ident_str,
-                traced_function = &#ident_str
-                #(, #param_names = tokio_trace::field::debug(&#param_names_clone)),*
-            )
-            .enter(move || {
-                #block
-            })
-        }
-    )
-    .into()
+    let span = quote! {
+        span!(
+            tokio_trace::Level::TRACE,
+            #ident_str,
+            traced_function = &#ident_str
+            #(, #param_names = tokio_trace::field::debug(&#param_names_clone)),*
+        )
+    };
+
+    function.block.stmts = quote_spanned!(call_site =>
+        #span.enter(move || {
+            #body
+        })
+    );
+
+    quote!(#function).into()
 }


### PR DESCRIPTION
Prior to this change re running `record` on field in a span would append a second copy of that field with the new value to the String representation of the fields.

This commit reworks span fields to be stored in a HashMap instead of a String so that updates can replace the old value rather than living along side it.

Benchmarks are still needed eventually to compare performance and possibly optimize things a bit.