### PR TITLE
futures: Improve feature flags, add `tokio-executor` compat

### DIFF
--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -10,6 +10,7 @@ default = ["tokio"]
 futures = "0.1"
 tokio-trace = "0.1.0"
 tokio = { version = "0.1", optional = true }
+tokio-executor = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = "0.1"

--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.0.1"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 
 [features]
-default = ["with-tokio"]
-with-tokio = ["tokio"]
+default = ["tokio"]
 
 [dependencies]
 futures = "0.1"

--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -4,7 +4,7 @@ use futures::{
 };
 use {Instrument, Instrumented, WithDispatch};
 
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 use tokio::{
     executor::{Executor as TokioExecutor, SpawnError},
     runtime::{current_thread, Runtime, TaskExecutor},
@@ -31,7 +31,7 @@ where
     }
 }
 
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 impl<T> TokioExecutor for Instrumented<T>
 where
     T: TokioExecutor,
@@ -46,7 +46,7 @@ where
     }
 }
 
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 impl Instrumented<Runtime> {
     /// Spawn an instrumented future onto the Tokio runtime.
     ///
@@ -102,7 +102,7 @@ impl Instrumented<Runtime> {
     }
 }
 
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 impl Instrumented<current_thread::Runtime> {
     /// Spawn an instrumented future onto the single-threaded Tokio runtime.
     ///
@@ -176,7 +176,7 @@ where
     }
 }
 
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 impl<T> TokioExecutor for WithDispatch<T>
 where
     T: TokioExecutor,
@@ -191,7 +191,7 @@ where
     }
 }
 
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 impl WithDispatch<Runtime> {
     /// Spawn a future onto the Tokio runtime, in the context of this
     /// `WithDispatch`'s trace dispatcher.
@@ -250,7 +250,7 @@ impl WithDispatch<Runtime> {
     }
 }
 
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 impl WithDispatch<current_thread::Runtime> {
     /// Spawn a future onto the single-threaded Tokio runtime, in the context
     /// of this `WithDispatch`'s trace dispatcher.

--- a/tokio-trace-futures/src/executor.rs
+++ b/tokio-trace-futures/src/executor.rs
@@ -4,11 +4,12 @@ use futures::{
 };
 use {Instrument, Instrumented, WithDispatch};
 
+#[cfg(all(feature = "tokio", not(feature = "tokio-executor")))]
+use tokio::executor::{Executor as TokioExecutor, SpawnError};
 #[cfg(feature = "tokio")]
-use tokio::{
-    executor::{Executor as TokioExecutor, SpawnError},
-    runtime::{current_thread, Runtime, TaskExecutor},
-};
+use tokio::runtime::{current_thread, Runtime, TaskExecutor};
+#[cfg(feature = "tokio-executor")]
+use tokio_executor::{Executor as TokioExecutor, SpawnError};
 
 macro_rules! deinstrument_err {
     ($e:expr) => {
@@ -31,7 +32,7 @@ where
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 impl<T> TokioExecutor for Instrumented<T>
 where
     T: TokioExecutor,
@@ -176,7 +177,7 @@ where
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(any(feature = "tokio", feature = "tokio-executor"))]
 impl<T> TokioExecutor for WithDispatch<T>
 where
     T: TokioExecutor,

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -11,6 +11,9 @@
 //!    This is intended primarily for use in crates which depend on
 //!    `tokio-executor` rather than `tokio`; in general the `tokio` feature
 //!    should be used instead.
+//!
+//! [`Instrument`]: trait.Instrument.html
+//! [`WithSubscriber`]: trait.WithSubscriber.html
 extern crate futures;
 #[cfg(feature = "tokio")]
 extern crate tokio;

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,6 +1,21 @@
+//! Futures compatibility for `tokio-trace`
+//!
+//! # Feature flags
+//! - `tokio`: Enables compatibility with the `tokio` crate, including
+//!    [`Instrument`] and [`WithSubscriber`] implementations for
+//!    `tokio::executor::Executor`, `tokio::runtime::Runtime`, and
+//!    `tokio::runtime::current_thread`. Enabled by default.
+//! - `tokio-executor`: Enables compatibility with the `tokio-executor`
+//!    crate, including  [`Instrument`] and [`WithSubscriber`]
+//!    implementations for types implementing `tokio_executor::Executor`.
+//!    This is intended primarily for use in crates which depend on
+//!    `tokio-executor` rather than `tokio`; in general the `tokio` feature
+//!    should be used instead.
 extern crate futures;
 #[cfg(feature = "tokio")]
 extern crate tokio;
+#[cfg(feature = "tokio-executor")]
+extern crate tokio_executor;
 #[cfg_attr(test, macro_use)]
 extern crate tokio_trace;
 

--- a/tokio-trace-futures/src/lib.rs
+++ b/tokio-trace-futures/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate futures;
-#[cfg(feature = "with-tokio")]
+#[cfg(feature = "tokio")]
 extern crate tokio;
 #[cfg_attr(test, macro_use)]
 extern crate tokio_trace;


### PR DESCRIPTION
This branch simplifies the feature flags used in the
`tokio-trace-futures` crate, and adds compatibility with the
`tokio-executor` crate. The feature formerly called `with-tokio` was
replaced by enabling the optional `tokio` dependency as a feature flag,
and a new `tokio-executor` optional dependency has been added, which
provides additional impls for types implementing
`tokio_executor::Executor`. This allows these impls to be used in crates
that depend on `tokio-executor` rather than `tokio`

Signed-off-by: Eliza Weisman <eliza@buoyant.io>