### PR TITLE
chore: Upgrade tokio version in examples/tests

### DIFF
--- a/tokio-trace-env-logger/Cargo.toml
+++ b/tokio-trace-env-logger/Cargo.toml
@@ -15,4 +15,4 @@ tokio-trace-futures = { path = "../tokio-trace-futures" }
 tokio-trace-subscriber = { path = "../tokio-trace-subscriber" }
 hyper = "=0.12.25"
 futures = "0.1"
-tokio = "0.1"
+tokio = "0.1.21"

--- a/tokio-trace-futures/Cargo.toml
+++ b/tokio-trace-futures/Cargo.toml
@@ -13,5 +13,5 @@ tokio = { version = "0.1", optional = true }
 tokio-executor = { version = "0.1", optional = true }
 
 [dev-dependencies]
-tokio = "0.1"
+tokio = "0.1.21"
 tokio-trace-fmt = { path = "../tokio-trace-fmt" }


### PR DESCRIPTION
This branch updates the dev-dependency `tokio` versions to 0.1.21, which
depends on tokio-trace-core 0.2. This should resolve issues where
examples and tests did not properly propagate the subscriber contexts
due to a `tokio-trace-core` version mismatch.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>