### PR TITLE
fmt: Make ReloadFilter generic over recorder

### DIFF
--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -79,13 +79,13 @@ where
     }
 }
 
-impl<N, E, F> FmtSubscriber<N, E, filter::ReloadFilter<F>>
+impl<N, E, F> FmtSubscriber<N, E, filter::ReloadFilter<F, N>>
 where
     F: Filter<N> + 'static,
 {
     /// Returns a `Handle` that may be used to reload this subscriber's
     /// filter.
-    pub fn reload_handle(&self) -> filter::reload::Handle<F> {
+    pub fn reload_handle(&self) -> filter::reload::Handle<F, N> {
         self.filter.handle()
     }
 }
@@ -235,7 +235,7 @@ where
 {
     /// Configures the subscriber being built to allow filter reloading at
     /// runtime.
-    pub fn with_filter_reloading(self) -> Builder<N, E, filter::ReloadFilter<F>> {
+    pub fn with_filter_reloading(self) -> Builder<N, E, filter::ReloadFilter<F, N>> {
         Builder {
             new_visitor: self.new_visitor,
             fmt_event: self.fmt_event,
@@ -245,13 +245,13 @@ where
     }
 }
 
-impl<N, E, F> Builder<N, E, filter::ReloadFilter<F>>
+impl<N, E, F> Builder<N, E, filter::ReloadFilter<F, N>>
 where
     F: Filter<N> + 'static,
 {
     /// Returns a `Handle` that may be used to reload the constructed subscriber's
     /// filter.
-    pub fn reload_handle(&self) -> filter::reload::Handle<F> {
+    pub fn reload_handle(&self) -> filter::reload::Handle<F, N> {
         self.filter.handle()
     }
 }


### PR DESCRIPTION
This branch changes the `ReloadFilter` and `Handle` types in
`ReloadFilter` to be generic over the context's `NewRecorder` type,
rather than making the reloading _functions_ generic over that type.
This prevents situations where the `NewRecorder` type is uninferrable.

Fixes #63

Signed-off-by: Eliza Weisman <eliza@buoyant.io>