### PR TITLE
fmt: re-export Context

### DIFF
--- a/tokio-trace-fmt/src/lib.rs
+++ b/tokio-trace-fmt/src/lib.rs
@@ -22,6 +22,7 @@ pub mod filter;
 mod span;
 
 pub use filter::Filter;
+pub use span::Context;
 
 #[derive(Debug)]
 pub struct FmtSubscriber<


### PR DESCRIPTION
Currently, the `span::Context` type in `tokio-trace-fmt` is required to
write custom formatting functions, as is part of the signature of
`on_event`, etc. However, it is in the private `span` module, and is not
re-exported. This effectively seals the method signature necessary for
`on_event` formatters, meaning custom formatters may not be written.

This branch re-exports `Context` publically so that users may implement
their own formatting functions.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>