### PR TITLE
log: `LogTracer` checks if events are enabled

### DIFF
--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -35,8 +35,7 @@ use std::{
 
 use tokio_trace::{
     callsite::{self, Callsite},
-    dispatcher,
-    field,
+    dispatcher, field,
     metadata::Kind,
     span,
     subscriber::{self, Subscriber},

--- a/tokio-trace-log/src/lib.rs
+++ b/tokio-trace-log/src/lib.rs
@@ -35,6 +35,7 @@ use std::{
 
 use tokio_trace::{
     callsite::{self, Callsite},
+    dispatcher,
     field,
     metadata::Kind,
     span,
@@ -186,7 +187,19 @@ impl log::Log for LogTracer {
     }
 
     fn log(&self, record: &log::Record) {
-        format_trace(record).unwrap();
+        let enabled = dispatcher::get_default(|dispatch| {
+            // TODO: can we cache this for each log record, so we can get
+            // similar to the callsite cache?
+            dispatch.enabled(&record.as_trace())
+        });
+
+        if enabled {
+            // TODO: if the record is enabled, we'll get the current dispatcher
+            // twice --- once to check if enabled, and again to dispatch the event.
+            // If we could construct events without dispatching them, we could
+            // re-use the dispatcher reference...
+            format_trace(record).unwrap();
+        }
     }
 
     fn flush(&self) {}


### PR DESCRIPTION
## Motivation

Currently, the `LogTracer` adapter in `tokio-trace-log` does not check
if an event translated from a `log` record would be enabled by the
current dispatcher, and _always_ dispatches the event. This means that
the `tokio-trace` subscribers never have the opportunity to filter that
event.

## Solution

This branch changes the `LogTracer` to call `enabled` on the current
dispatcher before creating an event. Unfortunately, we can't do this in
the `log::Log::enabled` impl for `LogTracer`, since the `log::Metadata`
lacks all the information required to create a `tokio_trace::Metadata`.

There are some potential improvements that we can make as follow-ups: in
particular, the `LogTracer` can keep its own cache of log records and
`Interests`, similar to the callsite cache, to avoid re-evaluating
filters. Additionally, if we add an `Event::new` (see
tokio-rs/tokio#1149), we can eliminate a redundant thread-local storage
access. I'll open issues for these changes as follow-ups.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
