### PR TITLE
fmt: add support for `off` filter directives

### DIFF
--- a/tokio-trace-fmt/src/filter/env.rs
+++ b/tokio-trace-fmt/src/filter/env.rs
@@ -323,7 +323,6 @@ impl PartialEq<Level> for LevelFilter {
     }
 }
 
-
 impl PartialOrd<Level> for LevelFilter {
     fn partial_cmp(&self, other: &Level) -> Option<Ordering> {
         match self {


### PR DESCRIPTION
## Motivation

The `env_logger` crate allows log directives ending in `off` to
_disable_ all logging from a matching target. However,
`tokio-trace-fmt`'s `EnvFilter` does not.

For example:
``` 
ignoring invalid log directive 'linkerd2_proxy::proxy::canonicalize=off'
ignoring invalid log directive 'linkerd2_proxy::proxy::http::router=off' 
ignoring invalid log directive 'linkerd2_proxy::proxy::tcp=off' 
```

`env_logger` accepts these directives.

## Solution

This branch adds support for directives with `off`. It was necessary to
reimplement a `LevelFilter` type, here similar to the one in
`tokio-trace`, as `tokio-trace-fmt` only depends on `tokio-trace-core`.

Fixes: #68

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
